### PR TITLE
ZEPHYR-34323: Mapping requirement using testcaseId

### DIFF
--- a/src/main/java/com/thed/zephyr/jenkins/reporter/UploadResultCallable.java
+++ b/src/main/java/com/thed/zephyr/jenkins/reporter/UploadResultCallable.java
@@ -750,7 +750,7 @@ public class UploadResultCallable extends MasterToSlaveFileCallable<Boolean> {
                         }
 
                         MapTestcaseToRequirement mapTestcaseToRequirement = (MapTestcaseToRequirement) entry.getValue().get("mapTestcaseToRequirement");
-                        mapTestcaseToRequirement.setTestcaseId(tcrCatalogTreeTestcase.getTestcase().getId());
+                        mapTestcaseToRequirement.setTestcaseId(tcrCatalogTreeTestcase.getTestcase().getTestcaseId());
                         mapTestcaseToRequirements.add(mapTestcaseToRequirement);
 
                         if (entry.getValue().containsKey("attachments")) {


### PR DESCRIPTION
Mapping requirement with testcase using testcaseId instead of testcaseVersionId