### PR TITLE
ZEPHYR-34689: Add accessType header to login request

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
     <repository>
       <id>inhouse</id>
       <name>theD Internal repository</name>
-      <url>http://svninfra.yourzephyr.com/repository/</url>
+      <url>https://svninfra.yourzephyr.com/repository/</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>

--- a/src/main/java/com/thed/service/impl/ZephyrRestServiceImpl.java
+++ b/src/main/java/com/thed/service/impl/ZephyrRestServiceImpl.java
@@ -139,9 +139,7 @@ public class ZephyrRestServiceImpl implements ZephyrRestService {
         httpClientService.clear();
         String encoding = Base64.getEncoder().encodeToString((username+":"+password).getBytes());
         httpClientService.getHeaders().add(new BasicHeader("Authorization", "Basic "+encoding));
-        httpClientService.getHeaders().add(new BasicHeader("accessType", "HTMLUI"));
         String res = httpClientService.getRequest(url);
-        httpClientService.getHeaders().clear();
         if(res != null) {
             setCurrentUser(GsonUtil.CUSTOM_GSON.fromJson(res, User.class));
             setHostAddress(hostAddress);

--- a/src/main/java/com/thed/service/impl/ZephyrRestServiceImpl.java
+++ b/src/main/java/com/thed/service/impl/ZephyrRestServiceImpl.java
@@ -139,6 +139,7 @@ public class ZephyrRestServiceImpl implements ZephyrRestService {
         httpClientService.clear();
         String encoding = Base64.getEncoder().encodeToString((username+":"+password).getBytes());
         httpClientService.getHeaders().add(new BasicHeader("Authorization", "Basic "+encoding));
+        httpClientService.getHeaders().add(new BasicHeader("accessType", "HTMLUI"));
         String res = httpClientService.getRequest(url);
         httpClientService.getHeaders().clear();
         if(res != null) {


### PR DESCRIPTION
Add accessType header to login request and update pom.xml to use https for svninfra resource

ZENG-1090
ZEPHYR-34689

Co-authored-by: Slawomir Oleksy <slawomir.oleksy@smartbear.com>
Co-authored-by: Jakub Pawlak <jakub.pawlak@smartbear.com>

[ZENG-1090]: https://smartbear.atlassian.net/browse/ZENG-1090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ZEPHYR-34689]: https://smartbear.atlassian.net/browse/ZEPHYR-34689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ