### PR TITLE
moved plugin description to index.jelly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,6 @@
     <version>2.9-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Zephyr Enterprise Test Management plugin</name>
-    <description>Creates Test Cases and update their statuses for unit tests.</description>
     <url>https://github.com/jenkinsci/zephyr-enterprise-test-management-plugin</url>
     <developers>
         <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>zephyr-enterprise-test-management</artifactId>
-    <version>2.9-SNAPSHOT</version>
+    <version>2.9</version>
     <packaging>hpi</packaging>
     <name>Zephyr Enterprise Test Management plugin</name>
     <url>https://github.com/jenkinsci/zephyr-enterprise-test-management-plugin</url>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,6 +1,7 @@
 <!--
   This view is used to render the installed plugins page.
 -->
+<?jelly escape-by-default='true'?>
 <div>
-This plugin creates test cases in Zephyr for the project unit tests.
+This plugin creates test cases and updates their statuses in Zephyr for the project unit tests.
 </div>


### PR DESCRIPTION
https://www.jenkins.io/doc/developer/tutorial-improve/move-description-to-index/

to resolve below when `mvn clean hpi:hpi`
```
[ERROR] Failed to execute goal org.jenkins-ci.tools:maven-hpi-plugin:3.53:hpi (default-cli) on project zephyr-enterprise-test-management: Missing C:\Users\ashutosh.kumar\Desktop\zephyr-enterprise-test-management-plugin\target\classes\index.jelly. Delete any <description> from pom.xml and create src/main/resources/index.jelly:
[ERROR] <?jelly escape-by-default='true'?>
[ERROR] <div>
[ERROR]     The description here?
[ERROR] </div>
```